### PR TITLE
:sparkles: feat: enhance cli version cmd

### DIFF
--- a/commands/commander.go
+++ b/commands/commander.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	env     string
-	version = "1.0.4"
+	version = "1.1.0"
 )
 
 func Execute(args []string) error {

--- a/commands/commander.go
+++ b/commands/commander.go
@@ -176,12 +176,14 @@ var versionCmd = &cobra.Command{
 	Long: `ℹ️  Manuscript CLI Version Information
 
 Shows:
-🔷 CLI version
-🔷 Build info (coming soon)
-🔷 API versions (coming soon)`,
+🛠️ Manuscript Core version
+🏗️ Build info
+💻 System information
+🐳 Docker environment details`,
 	Example: `>> manuscript-cli version`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("manuscript-cli version %s\n", version)
+		verbosity, _ := cmd.Flags().GetBool("verbose")
+		showVersion(verbosity)
 	},
 }
 
@@ -211,6 +213,9 @@ func init() {
 	// Configure deployment flags
 	deployManuscript.Flags().StringVar(&env, "env", "", "Specify the environment to deploy (local or chainbase)")
 	deployManuscript.MarkFlagRequired("env")
+
+	// Configure version command flags
+	versionCmd.Flags().BoolP("verbose", "v", false, "Display detailed version information")
 
 	// Disable the default completion command
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true

--- a/commands/version_manuscript.go
+++ b/commands/version_manuscript.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Build-time variables set via ldflags
+// Build command would be:
+// go build -ldflags "-X commands.gitCommit=$(git rev-parse --short HEAD) -X commands.buildDate=$(date -u +%Y-%m-%d:%H:%M:%S) -X commands.goVersion=$(go version | cut -d' ' -f3) -X commands.rustVersion=$(rustc --version | cut -d' ' -f2)"
+var (
+	gitCommit   = "unknown" // Set by build flags
+	buildDate   = "unknown" // Set by build flags
+	goVersion   = "unknown" // Set by build flags
+	rustVersion = "unknown" // Set by build flags
+)
+
+type VersionInfo struct {
+	Version     string     `json:"version"`
+	GoVersion   string     `json:"go_version"`
+	RustVersion string     `json:"rust_version"`
+	GitCommit   string     `json:"git_commit"`
+	BuildDate   string     `json:"build_date"`
+	OS          string     `json:"os"`
+	Arch        string     `json:"arch"`
+	DockerInfo  DockerInfo `json:"docker_info"`
+}
+
+type DockerInfo struct {
+	Version        string `json:"version"`
+	DesktopVersion string `json:"desktop_version"`
+}
+
+func showVersion(verbose bool) {
+	info := getVersionInfo()
+
+	if !verbose {
+		fmt.Printf("manuscript-core version %s\n", info.Version)
+		return
+	}
+
+	fmt.Printf("\n📜 Manuscript Core:\n")
+	fmt.Printf("  Version:\t%s\n", info.Version)
+
+	fmt.Printf("\n🏗️  Build Information:\n")
+	fmt.Printf("  Go Version:\t%s\n", info.GoVersion)
+	fmt.Printf("  Rust Version:\t%s\n", info.RustVersion)
+	fmt.Printf("  Git Commit:\t%s\n", info.GitCommit)
+	fmt.Printf("  Built:\t%s\n", info.BuildDate)
+
+	fmt.Printf("\n💻 System Information:\n")
+	uname, _ := exec.Command("uname", "-a").Output()
+	fmt.Printf("  Unix Name:\t%s", string(uname))
+	fmt.Printf("  OS/Arch:\t%s/%s\n", info.OS, info.Arch)
+
+	fmt.Printf("\n🐳 Docker Environment:\n")
+	if info.DockerInfo.Version != "" {
+		fmt.Printf("  Docker:\t'%s'\n", info.DockerInfo.Version)
+	}
+	if info.DockerInfo.DesktopVersion != "" {
+		fmt.Printf("  Docker Desktop:\t'%s'\n", info.DockerInfo.DesktopVersion)
+	}
+}
+
+func getVersionInfo() VersionInfo {
+	info := VersionInfo{
+		Version:     version,
+		GoVersion:   goVersion,
+		RustVersion: rustVersion,
+		GitCommit:   gitCommit,
+		BuildDate:   buildDate,
+		OS:          runtime.GOOS,
+		Arch:        runtime.GOARCH,
+	}
+
+	// Get Docker version
+	if dockerVersion, err := exec.Command("docker", "--version").Output(); err == nil {
+		version := strings.TrimSpace(string(dockerVersion))
+		parts := strings.Split(version, " ")
+		if len(parts) >= 3 {
+			info.DockerInfo.Version = strings.Trim(parts[2], ",")
+		}
+	}
+
+	// Get Docker Desktop version
+	cmd := exec.Command("docker", "version", "--format", "{{.Server}} {{.Server.Platform.Name}}")
+	if desktopVersion, err := cmd.Output(); err == nil {
+		// Find "Docker Desktop" and extract version
+		output := string(desktopVersion)
+		if strings.Contains(output, "Docker Desktop") {
+			parts := strings.Split(output, "Docker Desktop")
+			if len(parts) > 1 {
+				info.DockerInfo.DesktopVersion = strings.Split(parts[1], " ")[1]
+			}
+		}
+	}
+
+	return info
+}

--- a/commands/version_manuscript.go
+++ b/commands/version_manuscript.go
@@ -9,7 +9,12 @@ import (
 
 // Build-time variables set via ldflags
 // Build command would be:
-// go build -ldflags "-X commands.gitCommit=$(git rev-parse --short HEAD) -X commands.buildDate=$(date -u +%Y-%m-%d:%H:%M:%S) -X commands.goVersion=$(go version | cut -d' ' -f3) -X commands.rustVersion=$(rustc --version | cut -d' ' -f2)"
+//
+//	go build -ldflags "-X manuscript-core/commands.gitCommit=$(git rev-parse --short HEAD) \
+//	                  -X manuscript-core/commands.buildDate=$(date -u '+%Y-%m-%d:%H:%M:%S') \
+//						 -X manuscript-core/commands.goVersion=$(go version | cut -d' ' -f3) \
+//	                  -X manuscript-core/commands.rustVersion=$(rustc --version | cut -d' ' -f2)" \
+//	       -o manuscript-cli main.go
 var (
 	gitCommit   = "unknown" // Set by build flags
 	buildDate   = "unknown" // Set by build flags


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [X] Please open an issue before creating a PR or link to an existing issue
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

# Description

## New Output Format
When running `manuscript-cli version` with `--verbose` or `-v`, users now see:

```
📜 Manuscript Core:
  Version:    1.1.0

🏗️ Build Information:
  Go Version: go1.21.1
  Rust Version: 1.75.0
  Git Commit: a1b2c3d
  Built: 2024-02-14:12:34:56

💻 System Information:
  UNAME: Darwin MacBook-Pro.local 23.0.0
  OS/Arch: darwin/arm64

🐳 Docker Environment:
  Docker: '27.3.1'
  Docker Desktop: '4.36.0'
```



## Changes
- Added `--verbose/-v` flag to `version` command for detailed system information
- Moved version-related code to dedicated `version_manuscript.go` file
- Improved version information structure and organization
- Added cross-platform Docker and Docker Desktop version detection

Fixes Issue #70 

## Build Instructions
> [!IMPORTANT]
> Getting useful debug information from the version command requires setting certain `ldflags` at build time.

All version information should be injected at build time using:
```bash
go build -ldflags "
  -X manuscript-core/commands.gitCommit=$(git rev-parse --short HEAD)
  -X manuscript-core/commands.buildDate=$(date -u +%Y-%m-%d:%H:%M:%S)
  -X manuscript-core/commands.goVersion=$(go version | cut -d' ' -f3)
  -X manuscript-core/commands.rustVersion=$(rustc --version | cut -d' ' -f2)"
"
```
In the future, this can be abstracted to a make file for simplicity, if desired.

If these flags are not set when the binary is compiled, they will be set to a default `unknown` string:
![image](https://github.com/user-attachments/assets/97696f4a-14f0-4cc6-ba2a-7922d1bc8f72)

## Type of Change

- [x] New feature
- [x] Enhancement, including but not limited to code refactoring, performance optimization, Test and CI
