### PR TITLE
:hammer: fix: repair broken init_manuscript table selection

### DIFF
--- a/commands/init_manuscript.go
+++ b/commands/init_manuscript.go
@@ -101,7 +101,7 @@ func InitManuscript() {
 	}
 
 	selectedChain, selectedDatabase := selectChain(chains, "🏂 3. Please select a chainbase network dataset from the list below: ", defaultDatabase)
-	selectedTable := selectTable(chains, selectedChain, "🧲 4. Please select a table from the list below: ", defaultTable)
+	selectedTable := selectTable(chains, selectedChain, defaultDatabase, "🧲 4. Please select a table from the list below: ", defaultTable)
 
 	outputChoice := promptOutputTarget()
 	fmt.Printf("\n\033[33m🏄🏄 Summary of your selections:\033[0m\n")
@@ -354,23 +354,41 @@ func selectChain(chains []*client.ChainBaseDatasetListItem, prompt, defaultChain
 	return chains[index-1].Name, chains[index-1].DatabaseName
 }
 
-func selectTable(chains []*client.ChainBaseDatasetListItem, selectedChain, prompt, defaultTable string) string {
-	defaultChainIndex := 1
+func selectTable(chains []*client.ChainBaseDatasetListItem, selectedChain, defaultChain, prompt, defaultTable string) string {
 	fmt.Println("\r\033[33m" + prompt + "\u001B[0m")
-	for i, table := range chains[defaultChainIndex].Tables {
+
+	// Find the chain in the list
+	var chainIndex int
+	for i, chain := range chains {
+		if chain.Name == selectedChain || chain.DatabaseName == selectedChain {
+			chainIndex = i
+			break
+		}
+	}
+
+	// Display available tables
+	availableTables := chains[chainIndex].Tables
+	for i, table := range availableTables {
 		fmt.Printf("%d: %s\n", i+1, table)
 	}
+
+	// Prompt user for table choice
 	tableChoice := promptInput("Enter your choice(default is blocks)\u001B[0m: ", "")
 	if tableChoice == "" {
 		fmt.Printf("\u001B[32m✓ Defaulting to table: %s\u001B[0m\n\n", defaultTable)
 		return defaultTable
 	}
+
+	// Validate user input
 	index, err := strconv.Atoi(tableChoice)
-	if err != nil || index < 1 || index > len(chains[defaultChainIndex].Tables) {
+	if err != nil || index < 1 || index > len(availableTables) {
 		fmt.Printf("Invalid choice. Defaulting to table: %s\n", defaultTable)
 		return defaultTable
 	}
-	tableName := chains[defaultChainIndex].Tables[index-1]
+
+	// Return selected table
+	tableName := availableTables[index-1]
+	// Handle special case if transaction logs is selected
 	if tableName == "transactionLogs" {
 		tableName = "transaction_logs"
 	}

--- a/static/docker_compose_template.go
+++ b/static/docker_compose_template.go
@@ -1,10 +1,9 @@
 package static
 
 var DockerComposeTemplate = `
-version: '3.2'
 name: {{.Name}}
 services:
-  jobmanager: 
+  jobmanager:
     image: repository.chainbase.com/manuscript-node/manuscript-node:latest
     user: "flink"
     command: "standalone-job --job-classname com.chainbase.manuscript.ETLProcessor /opt/flink/manuscript.yaml --fromSavepoint /opt/flink/savepoint"
@@ -37,7 +36,6 @@ networks:
   ms_network:`
 
 var DockerComposeWithPostgresqlContent = `
-version: '3.2'
 name: {{.Name}}
 services:
   jobmanager:


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [X] Please open an issue before creating a PR or link to an existing issue
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

# Description
The PR is designed to fix the issue that caused all tables to display `SOL` data.  The table selection was previously erroneously hardcoded. I worked to improve chain indexing to correctly map selected chains to their available tables.  As a side note, Docker Compose V2 no longer requires version specification, and its presence generates warning messages  - so I modified the docker compose template files to adjust it. 

## Changes
1. Refactored `selectTable` function to properly handle chain selection and table listing
2. Removed obsolete `version` tag from Docker Compose template
3. Removed redundant chain selection guard clause

## Outcomes 
### For `zkevm`
![image](https://github.com/user-attachments/assets/378289b3-54ad-40de-b9fd-71c41e11559b)

### For `ethereum`
![image](https://github.com/user-attachments/assets/bfaedfa1-a582-4f7b-b695-e53aab6230c3)


Fixes #81 

## Type of Change

- [X] Bug fix
