### PR TITLE
🚑️ [fix] restore network list functionality

### DIFF
--- a/client/network_chains.go
+++ b/client/network_chains.go
@@ -9,8 +9,9 @@ import (
 )
 
 type ChainBaseClient struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL       string
+	chainEndpoint string
+	httpClient    *http.Client
 }
 
 type ChainBaseDatasetListItem struct {
@@ -20,23 +21,23 @@ type ChainBaseDatasetListItem struct {
 }
 
 type ChainResponse struct {
-    Code           int    `json:"code"`
-    Message        string `json:"message"`
-    GraphData      []struct {
-        Chain struct {
-            ID             string                 `json:"id"`
-            Name           string                 `json:"name"`
-            DatabaseName   string                 `json:"databaseName"`
-            DataDictionary map[string][]TableInfo `json:"dataDictionary"`
-        } `json:"chain"`
-    } `json:"graphData"`
-    TransactionLogs *[]TransactionLog `json:"transactionLogs,omitempty"`
+	Code      int    `json:"code"`
+	Message   string `json:"message"`
+	GraphData []struct {
+		Chain struct {
+			ID             string                 `json:"id"`
+			Name           string                 `json:"name"`
+			DatabaseName   string                 `json:"databaseName"`
+			DataDictionary map[string][]TableInfo `json:"dataDictionary"`
+		} `json:"chain"`
+	} `json:"graphData"`
+	TransactionLogs *[]TransactionLog `json:"transactionLogs,omitempty"`
 }
 
 type TransactionLog struct {
-    Timestamp string `json:"timestamp"`
-    Action    string `json:"action"`
-    Details   string `json:"details"`
+	Timestamp string `json:"timestamp"`
+	Action    string `json:"action"`
+	Details   string `json:"details"`
 }
 
 type TableInfo struct {
@@ -45,9 +46,10 @@ type TableInfo struct {
 	Description string `json:"description"`
 }
 
-func NewChainBaseClient(baseURL string) *ChainBaseClient {
+func NewChainBaseClient(baseURL string, chainEndpoint string) *ChainBaseClient {
 	return &ChainBaseClient{
-		baseURL: baseURL,
+		baseURL:       baseURL,
+		chainEndpoint: chainEndpoint,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -55,7 +57,7 @@ func NewChainBaseClient(baseURL string) *ChainBaseClient {
 }
 
 func (c *ChainBaseClient) GetChainBaseDatasetList() ([]*ChainBaseDatasetListItem, error) {
-	url := fmt.Sprintf("%s/api/v1/metadata/network_chains", c.baseURL)
+	url := fmt.Sprintf("%s%s", c.baseURL, c.chainEndpoint)
 
 	resp, err := c.httpClient.Get(url)
 	if err != nil {

--- a/client/network_chains_test.go
+++ b/client/network_chains_test.go
@@ -56,7 +56,7 @@ func TestGetChainBaseDatasetList(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	client := NewChainBaseClient(mockServer.URL)
+	client := NewChainBaseClient(mockServer.URL, "/api/v1/metadata/network_chains")
 
 	chains, err := client.GetChainBaseDatasetList()
 

--- a/commands/init_manuscript.go
+++ b/commands/init_manuscript.go
@@ -18,15 +18,16 @@ import (
 )
 
 const (
-	manuscriptBaseName = "manuscript"
-	manuscriptBaseDir  = "$HOME"
-	manuscriptConfig   = "$HOME/.manuscript_config.ini"
-	networkChainURL    = "https://api.chainbase.com"
-	defaultDatabase    = "zkevm"
-	defaultTable       = "blocks"
-	defaultSink        = "postgres"
-	graphQLImage       = "repository.chainbase.com/manuscript-node/graphql-engine:latest"
-	graphQLARMImage    = "repository.chainbase.com/manuscript-node/graphql-engine-arm64:latest"
+	manuscriptBaseName   = "manuscript"
+	manuscriptBaseDir    = "$HOME"
+	manuscriptConfig     = "$HOME/.manuscript_config.ini"
+	networkChainURL      = "https://api.chainbase.com"
+	networkChainEndpoint = "/api/v1/metadata/network_chains"
+	defaultDatabase      = "zkevm"
+	defaultTable         = "blocks"
+	defaultSink          = "postgres"
+	graphQLImage         = "repository.chainbase.com/manuscript-node/graphql-engine:latest"
+	graphQLARMImage      = "repository.chainbase.com/manuscript-node/graphql-engine-arm64:latest"
 )
 
 func executeInitManuscript(ms pkg.Manuscript) {
@@ -323,7 +324,7 @@ func checkDockerContainerExists(manuscriptName string) bool {
 func fetchChainBaseDatasets() ([]*client.ChainBaseDatasetListItem, error) {
 	var chains []*client.ChainBaseDatasetListItem
 	err := pkg.ExecuteStepWithLoading("Checking Datasets From Network", false, func() error {
-		c := client.NewChainBaseClient(networkChainURL)
+		c := client.NewChainBaseClient(networkChainURL, networkChainEndpoint)
 		var err error
 		chains, err = c.GetChainBaseDatasetList()
 		if err != nil {


### PR DESCRIPTION
This commit fixes a MAJOR error which was an incidental deletion of the network chain URL causing the CLI to error out instead of returning the list of manuscripts when using the `init` command.

# Description
An oversight caused code to be pushed that knocked out the network list fundamentally breaking the CLI init command.
This emergency fix, fixes basic CLI functionality by restoring the endpoint.

## Type of Change

- [X] Bug fix
