### PR TITLE
:bug: fix: eliminate zombie jobs

### DIFF
--- a/client/network_chains.go
+++ b/client/network_chains.go
@@ -9,8 +9,9 @@ import (
 )
 
 type ChainBaseClient struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL       string
+	chainEndpoint string
+	httpClient    *http.Client
 }
 
 type ChainBaseDatasetListItem struct {
@@ -20,23 +21,23 @@ type ChainBaseDatasetListItem struct {
 }
 
 type ChainResponse struct {
-    Code           int    `json:"code"`
-    Message        string `json:"message"`
-    GraphData      []struct {
-        Chain struct {
-            ID             string                 `json:"id"`
-            Name           string                 `json:"name"`
-            DatabaseName   string                 `json:"databaseName"`
-            DataDictionary map[string][]TableInfo `json:"dataDictionary"`
-        } `json:"chain"`
-    } `json:"graphData"`
-    TransactionLogs *[]TransactionLog `json:"transactionLogs,omitempty"`
+	Code      int    `json:"code"`
+	Message   string `json:"message"`
+	GraphData []struct {
+		Chain struct {
+			ID             string                 `json:"id"`
+			Name           string                 `json:"name"`
+			DatabaseName   string                 `json:"databaseName"`
+			DataDictionary map[string][]TableInfo `json:"dataDictionary"`
+		} `json:"chain"`
+	} `json:"graphData"`
+	TransactionLogs *[]TransactionLog `json:"transactionLogs,omitempty"`
 }
 
 type TransactionLog struct {
-    Timestamp string `json:"timestamp"`
-    Action    string `json:"action"`
-    Details   string `json:"details"`
+	Timestamp string `json:"timestamp"`
+	Action    string `json:"action"`
+	Details   string `json:"details"`
 }
 
 type TableInfo struct {
@@ -45,9 +46,10 @@ type TableInfo struct {
 	Description string `json:"description"`
 }
 
-func NewChainBaseClient(baseURL string) *ChainBaseClient {
+func NewChainBaseClient(baseURL string, chainEndpoint string) *ChainBaseClient {
 	return &ChainBaseClient{
-		baseURL: baseURL,
+		baseURL:       baseURL,
+		chainEndpoint: chainEndpoint,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -55,7 +57,7 @@ func NewChainBaseClient(baseURL string) *ChainBaseClient {
 }
 
 func (c *ChainBaseClient) GetChainBaseDatasetList() ([]*ChainBaseDatasetListItem, error) {
-	url := fmt.Sprintf("%s/api/v1/metadata/network_chains", c.baseURL)
+	url := fmt.Sprintf("%s%s", c.baseURL, c.chainEndpoint)
 
 	resp, err := c.httpClient.Get(url)
 	if err != nil {

--- a/client/network_chains_test.go
+++ b/client/network_chains_test.go
@@ -56,7 +56,7 @@ func TestGetChainBaseDatasetList(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	client := NewChainBaseClient(mockServer.URL)
+	client := NewChainBaseClient(mockServer.URL, "/api/v1/metadata/network_chains")
 
 	chains, err := client.GetChainBaseDatasetList()
 

--- a/commands/commander.go
+++ b/commands/commander.go
@@ -60,6 +60,8 @@ Each job shows:
 Status indicators:
 🟢 Running - Job is active and processing data
 🟡 Warning - Job needs attention
+🔴 Failed - Job encountered an error
+⚫ Stopped - Job was stopped
 ⚪️ Other - Various other states`,
 	Example: `>> manuscript-cli list`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/commands/commander.go
+++ b/commands/commander.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"log"
+	"manuscript-core/pkg"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -47,7 +49,7 @@ You'll be prompted to select:
 }
 
 var jobListCmd = &cobra.Command{
-	Use:     "list",
+	Use:     "list [directory]",
 	Aliases: []string{"ls"},
 	Short:   "List all manuscript jobs",
 	Long: `📋 View all running manuscript jobs
@@ -63,10 +65,26 @@ Status indicators:
 🟡 Warning - Job needs attention
 🔴 Failed - Job encountered an error
 ⚫ Stopped - Job was stopped
-⚪️ Other - Various other states`,
-	Example: `>> manuscript-cli list`,
+
+Usage:
+- Run without arguments to check default directory
+- Specify a directory path to check manuscripts in that location`,
+	Example: `>> manuscript-cli ls
+>> manuscript-cli list /path/to/manuscripts`,
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		ListJobs()
+		var dir string
+		// if no args, use default manuscript directory
+		if len(args) == 0 {
+			config, err := pkg.LoadConfig(manuscriptConfig)
+			if err != nil {
+				log.Fatalf("Error: Failed to load config: %v", err)
+			}
+			dir = fmt.Sprintf("%s/%s", config.BaseDir, manuscriptBaseName)
+		} else {
+			dir = args[0] // use specified directory if user input
+		}
+		ListJobs(dir)
 	},
 }
 

--- a/commands/commander.go
+++ b/commands/commander.go
@@ -47,8 +47,9 @@ You'll be prompted to select:
 }
 
 var jobListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all manuscript jobs",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List all manuscript jobs",
 	Long: `📋 View all running manuscript jobs
 
 Each job shows:

--- a/commands/init_manuscript.go
+++ b/commands/init_manuscript.go
@@ -18,15 +18,16 @@ import (
 )
 
 const (
-	manuscriptBaseName = "manuscript"
-	manuscriptBaseDir  = "$HOME"
-	manuscriptConfig   = "$HOME/.manuscript_config.ini"
-	networkChainURL    = "https://api.chainbase.com"
-	defaultDatabase    = "zkevm"
-	defaultTable       = "blocks"
-	defaultSink        = "postgres"
-	graphQLImage       = "repository.chainbase.com/manuscript-node/graphql-engine:latest"
-	graphQLARMImage    = "repository.chainbase.com/manuscript-node/graphql-engine-arm64:latest"
+	manuscriptBaseName   = "manuscript"
+	manuscriptBaseDir    = "$HOME"
+	manuscriptConfig     = "$HOME/.manuscript_config.ini"
+	networkChainURL      = "https://api.chainbase.com"
+	networkChainEndpoint = "/api/v1/metadata/network_chains"
+	defaultDatabase      = "zkevm"
+	defaultTable         = "blocks"
+	defaultSink          = "postgres"
+	graphQLImage         = "repository.chainbase.com/manuscript-node/graphql-engine:latest"
+	graphQLARMImage      = "repository.chainbase.com/manuscript-node/graphql-engine-arm64:latest"
 )
 
 func executeInitManuscript(ms pkg.Manuscript) {
@@ -323,7 +324,7 @@ func checkDockerContainerExists(manuscriptName string) bool {
 func fetchChainBaseDatasets() ([]*client.ChainBaseDatasetListItem, error) {
 	var chains []*client.ChainBaseDatasetListItem
 	err := pkg.ExecuteStepWithLoading("Checking Datasets From Network", false, func() error {
-		c := client.NewChainBaseClient(networkChainURL)
+		c := client.NewChainBaseClient(networkChainURL, networkChainEndpoint)
 		var err error
 		chains, err = c.GetChainBaseDatasetList()
 		if err != nil {

--- a/commands/jobs_manuscript.go
+++ b/commands/jobs_manuscript.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"manuscript-core/pkg"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -39,38 +41,108 @@ func formatDurationToMinutes(durationMs int64) string {
 	return fmt.Sprintf("%d minutes", durationMinutes)
 }
 
-func ListJobs() {
+func ListJobs(dir string) {
 	_ = pkg.ExecuteStepWithLoading("Checking jobs", false, func() error {
-		dockers, err := pkg.RunDockerPs()
+		// Step 1: Check for running Docker containers
+		dockers, err := getRunningContainers()
 		if err != nil {
-			log.Fatalf("Error: Failed to get docker ps: %v", err)
+			return err
 		}
 
+		// Always show if no containers are running
 		if len(dockers) == 0 {
-			fmt.Println("\r🟡 There are no jobs running...")
+			fmt.Println("\r📍 There are no jobs running...")
+		}
+
+		// Step 2: Get manuscripts based on source (config or directory)
+		manuscripts, err := getManuscripts(dir)
+		if err != nil {
+			return fmt.Errorf("failed to get manuscripts: %w", err)
+		}
+
+		if len(manuscripts) == 0 {
+			if dir != "" {
+				fmt.Printf("\r⚠️ No manuscript files found in %s\n", dir)
+			}
 			return nil
 		}
 
-		manuscripts, err := pkg.LoadConfig(manuscriptConfig)
-		if err != nil {
-			return fmt.Errorf("failed to load configuration: %w", err)
-		}
-
-		jobNumber := 0
-		for _, m := range manuscripts.Manuscripts {
-			jobNumber++
-
-			detector := pkg.NewStateDetector(&m, dockers)
-			state, err := detector.DetectState()
-			if err != nil {
-				log.Printf("Warning: Failed to detect state for %s: %v", m.Name, err)
-				state = pkg.StateUnknown
-			}
-
-			displayJobStatus(jobNumber, &m, state)
-		}
+		// Step 3: Check and display state for each manuscript
+		displayManuscriptStates(manuscripts, dockers)
 		return nil
 	})
+}
+
+// getRunningContainers retrieves all running Docker containers
+func getRunningContainers() ([]pkg.ContainerInfo, error) {
+	dockers, err := pkg.RunDockerPs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get docker processes: %w", err)
+	}
+	return dockers, nil
+}
+
+// getManuscripts retrieves manuscript configurations from either config file or directory
+func getManuscripts(dir string) ([]pkg.Manuscript, error) {
+	if dir == "" {
+		return getManuscriptsFromConfig()
+	}
+	return getManuscriptsFromDirectory(dir)
+}
+
+// getManuscriptsFromConfig loads manuscripts from the config file
+func getManuscriptsFromConfig() ([]pkg.Manuscript, error) {
+	config, err := pkg.LoadConfig(manuscriptConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load configuration: %w", err)
+	}
+	return config.Manuscripts, nil
+}
+
+// getManuscriptsFromDirectory scans directory for manuscript.yaml files
+func getManuscriptsFromDirectory(dir string) ([]pkg.Manuscript, error) {
+	// Check if directory exists
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("directory does not exist: %s", dir)
+	}
+
+	var manuscripts []pkg.Manuscript
+	// Read only the immediate subdirectories
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Check for manuscript.yaml in each immediate subdirectory
+			manuscriptPath := filepath.Join(dir, entry.Name(), "manuscript.yaml")
+			if _, err := os.Stat(manuscriptPath); err == nil {
+				manuscript, err := pkg.ParseYAML(manuscriptPath)
+				if err != nil {
+					log.Printf("Warning: Failed to parse %s: %v", manuscriptPath, err)
+					continue
+				}
+				manuscripts = append(manuscripts, *manuscript)
+			}
+		}
+	}
+
+	return manuscripts, nil
+}
+
+// displayManuscriptStates checks and displays the state of each manuscript
+func displayManuscriptStates(manuscripts []pkg.Manuscript, dockers []pkg.ContainerInfo) {
+	for i, m := range manuscripts {
+		detector := pkg.NewStateDetector(&m, dockers)
+		state, err := detector.DetectState()
+		if err != nil {
+			log.Printf("Warning: Failed to detect state for %s: %v", m.Name, err)
+			state = pkg.StateUnknown
+		}
+
+		displayJobStatus(i+1, &m, state)
+	}
 }
 
 func displayJobStatus(jobNumber int, m *pkg.Manuscript, state pkg.ManuscriptState) {

--- a/pkg/manuscript_state.go
+++ b/pkg/manuscript_state.go
@@ -1,0 +1,159 @@
+package pkg
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type ManuscriptState string
+
+const (
+	StateRunning      ManuscriptState = "RUNNING"
+	StateInitializing ManuscriptState = "INITIALIZING"
+	StateFailed       ManuscriptState = "FAILED"
+	StateStopped      ManuscriptState = "STOPPED"
+	StateUnknown      ManuscriptState = "UNKNOWN"
+)
+
+type StateDetector struct {
+	manuscript *Manuscript
+	containers []ContainerInfo
+}
+
+func NewStateDetector(manuscript *Manuscript, containers []ContainerInfo) *StateDetector {
+	return &StateDetector{
+		manuscript: manuscript,
+		containers: containers,
+	}
+}
+
+func (sd *StateDetector) findContainer(name string) *ContainerInfo {
+	for _, container := range sd.containers {
+		if container.Name == name {
+			return &container
+		}
+	}
+	return nil
+}
+
+func (sd *StateDetector) DetectState() (ManuscriptState, error) {
+	jobManagerName := fmt.Sprintf("%s-jobmanager-1", sd.manuscript.Name)
+	taskManagerName := fmt.Sprintf("%s-taskmanager-1", sd.manuscript.Name)
+
+	jobManager := sd.findContainer(jobManagerName)
+	taskManager := sd.findContainer(taskManagerName)
+
+	// If no containers are found, the job is stopped
+	if jobManager == nil && taskManager == nil {
+		return StateStopped, nil
+	}
+
+	// Check for failed state based on container status
+	if jobManager != nil && strings.Contains(jobManager.Status, "Exit") {
+		return StateFailed, nil
+	}
+	if taskManager != nil && strings.Contains(taskManager.Status, "Exit") {
+		return StateFailed, nil
+	}
+
+	// Analyze Flink logs to determine the current state
+	state, err := sd.analyzeFlinkLogs(jobManagerName)
+	if err != nil {
+		return StateUnknown, fmt.Errorf("failed to analyze logs: %w", err)
+	}
+
+	return state, nil
+}
+
+func (sd *StateDetector) analyzeFlinkLogs(containerName string) (ManuscriptState, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	logs, err := GetContainerLogs(ctx, containerName, 500)
+	if err != nil {
+		return StateUnknown, fmt.Errorf("failed to get container logs: %w", err)
+	}
+
+	var lastRunningMatch string
+	var lastInitMatch string
+	var lastFailMatch string
+	var lastFinishMatch string
+
+	patterns := map[string]*regexp.Regexp{
+		string(StateRunning): regexp.MustCompile(
+			`(Job .+\(.+\) (switched to RUNNING|switched from .+ to RUNNING)|` +
+				`Completed checkpoint \d+ for job)`),
+		string(StateFailed): regexp.MustCompile(
+			`(Job [a-f0-9-]+ \(.*\) switched to FAILED|` +
+				`Exception in thread|Error|FATAL|` +
+				`Task failure|JobManager failure)`),
+		string(StateInitializing): regexp.MustCompile(
+			`(Starting JobManager|` +
+				`Starting TaskManager|` +
+				`Created new job|` +
+				`Submitting job|` +
+				`Job [a-f0-9-]+ \(.*\) is being submitted)`),
+		string(StateRunning) + "_FINISHED": regexp.MustCompile(`Job [a-f0-9-]+ \(.*\) switched to FINISHED`),
+	}
+
+	// Scan logs from newest to oldest
+	for i := len(logs) - 1; i >= 0; i-- {
+		line := logs[i]
+		if patterns[string(StateRunning)].MatchString(line) && lastRunningMatch == "" {
+			lastRunningMatch = line
+		}
+		if patterns[string(StateFailed)].MatchString(line) && lastFailMatch == "" {
+			lastFailMatch = line
+		}
+		if patterns[string(StateInitializing)].MatchString(line) && lastInitMatch == "" {
+			lastInitMatch = line
+		}
+		if patterns[string(StateRunning)+"_FINISHED"].MatchString(line) && lastFinishMatch == "" {
+			lastFinishMatch = line
+		}
+	}
+
+	// Return state based on most recent relevant log entry
+	if lastFinishMatch != "" {
+		// If we found a FINISHED state and there's no FAILED state after it
+		if lastFailMatch == "" || strings.Index(lastFinishMatch, lastFailMatch) > 0 {
+			return StateRunning, nil
+		}
+	}
+	if lastRunningMatch != "" {
+		// If we found a RUNNING state and there's no FAILED state after it
+		if lastFailMatch == "" || strings.Index(lastRunningMatch, lastFailMatch) > 0 {
+			return StateRunning, nil
+		}
+	}
+	if lastFailMatch != "" {
+		return StateFailed, nil
+	}
+	if lastInitMatch != "" {
+		return StateInitializing, nil
+	}
+
+	return StateInitializing, nil
+}
+
+func GetContainerLogs(ctx context.Context, containerName string, lines int) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "docker", "logs", "--tail", fmt.Sprintf("%d", lines), containerName)
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	var logs []string
+	for scanner.Scan() {
+		logs = append(logs, scanner.Text())
+	}
+
+	return logs, scanner.Err()
+}

--- a/pkg/manuscript_state.go
+++ b/pkg/manuscript_state.go
@@ -153,8 +153,8 @@ func (sd *StateDetector) analyzeFlinkLogs(containerName string) (ManuscriptState
 		return StateInitializing, nil
 	}
 
-	// By default, return INITIALIZING state
-	return StateInitializing, nil
+	// By default, if a manuscript survives all checks, return RUNNING state
+	return StateRunning, nil
 }
 
 func GetContainerLogs(ctx context.Context, containerName string, lines int) ([]string, error) {

--- a/pkg/manuscript_state.go
+++ b/pkg/manuscript_state.go
@@ -10,8 +10,10 @@ import (
 	"time"
 )
 
+// ManuscriptState represents the current state of a Manuscript job
 type ManuscriptState string
 
+// Possible states of a Manuscript job
 const (
 	StateRunning      ManuscriptState = "RUNNING"
 	StateInitializing ManuscriptState = "INITIALIZING"
@@ -20,11 +22,13 @@ const (
 	StateUnknown      ManuscriptState = "UNKNOWN"
 )
 
+// StateDetector is responsible for detecting the current state of a Manuscript job
 type StateDetector struct {
 	manuscript *Manuscript
 	containers []ContainerInfo
 }
 
+// NewStateDetector creates a new StateDetector instance
 func NewStateDetector(manuscript *Manuscript, containers []ContainerInfo) *StateDetector {
 	return &StateDetector{
 		manuscript: manuscript,
@@ -32,6 +36,7 @@ func NewStateDetector(manuscript *Manuscript, containers []ContainerInfo) *State
 	}
 }
 
+// ContainerInfo represents information about a Docker container
 func (sd *StateDetector) findContainer(name string) *ContainerInfo {
 	for _, container := range sd.containers {
 		if container.Name == name {
@@ -41,19 +46,21 @@ func (sd *StateDetector) findContainer(name string) *ContainerInfo {
 	return nil
 }
 
+// DetectState determines the current state of the Manuscript job
 func (sd *StateDetector) DetectState() (ManuscriptState, error) {
+	// Find the job and task manager containers
 	jobManagerName := fmt.Sprintf("%s-jobmanager-1", sd.manuscript.Name)
 	taskManagerName := fmt.Sprintf("%s-taskmanager-1", sd.manuscript.Name)
 
 	jobManager := sd.findContainer(jobManagerName)
 	taskManager := sd.findContainer(taskManagerName)
 
-	// If no containers are found, the job is stopped
+	// If no containers are found, the job is considered STOPPED
 	if jobManager == nil && taskManager == nil {
 		return StateStopped, nil
 	}
 
-	// Check for failed state based on container status
+	// Check for FAILED state based on container status
 	if jobManager != nil && strings.Contains(jobManager.Status, "Exit") {
 		return StateFailed, nil
 	}
@@ -70,20 +77,25 @@ func (sd *StateDetector) DetectState() (ManuscriptState, error) {
 	return state, nil
 }
 
+// analyzeFlinkLogs scans the logs of a Flink container to determine the current state
 func (sd *StateDetector) analyzeFlinkLogs(containerName string) (ManuscriptState, error) {
+	// Create a context that will timeout after 5 seconds and ensure cleanup with defer
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	// Get the last 500 lines of logs
 	logs, err := GetContainerLogs(ctx, containerName, 500)
 	if err != nil {
 		return StateUnknown, fmt.Errorf("failed to get container logs: %w", err)
 	}
 
+	// Create variables to store the most recent relevant log entries
 	var lastRunningMatch string
 	var lastInitMatch string
 	var lastFailMatch string
 	var lastFinishMatch string
 
+	// Define regular expressions to match relevant log entries
 	patterns := map[string]*regexp.Regexp{
 		string(StateRunning): regexp.MustCompile(
 			`(Job .+\(.+\) (switched to RUNNING|switched from .+ to RUNNING)|` +
@@ -104,6 +116,7 @@ func (sd *StateDetector) analyzeFlinkLogs(containerName string) (ManuscriptState
 	// Scan logs from newest to oldest
 	for i := len(logs) - 1; i >= 0; i-- {
 		line := logs[i]
+		// Check if the log entry matches any of the relevant patterns
 		if patterns[string(StateRunning)].MatchString(line) && lastRunningMatch == "" {
 			lastRunningMatch = line
 		}
@@ -120,40 +133,47 @@ func (sd *StateDetector) analyzeFlinkLogs(containerName string) (ManuscriptState
 
 	// Return state based on most recent relevant log entry
 	if lastFinishMatch != "" {
-		// If we found a FINISHED state and there's no FAILED state after it
+		// If we found a FINISHED state and there's no FAILED state after it -> RUNNING
 		if lastFailMatch == "" || strings.Index(lastFinishMatch, lastFailMatch) > 0 {
 			return StateRunning, nil
 		}
 	}
 	if lastRunningMatch != "" {
-		// If we found a RUNNING state and there's no FAILED state after it
+		// If we found a RUNNING state and there's no FAILED state after it -> RUNNING
 		if lastFailMatch == "" || strings.Index(lastRunningMatch, lastFailMatch) > 0 {
 			return StateRunning, nil
 		}
 	}
 	if lastFailMatch != "" {
+		// If we found a FAILED pattern match, and it survived other checks -> FAILED
 		return StateFailed, nil
 	}
 	if lastInitMatch != "" {
+		// If we found an INITIALIZING pattern match, and it survived other checks -> INITIALIZING
 		return StateInitializing, nil
 	}
 
+	// By default, return INITIALIZING state
 	return StateInitializing, nil
 }
 
 func GetContainerLogs(ctx context.Context, containerName string, lines int) ([]string, error) {
+	// Create a command to get the logs of the container
 	cmd := exec.CommandContext(ctx, "docker", "logs", "--tail", fmt.Sprintf("%d", lines), containerName)
 
+	// Run the command and capture the output
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
 
+	// Split the output into individual log lines
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 	var logs []string
 	for scanner.Scan() {
 		logs = append(logs, scanner.Text())
 	}
 
+	// Return the logs and any error that occurred during scanning
 	return logs, scanner.Err()
 }


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [X] Please open an issue before creating a PR or link to an existing issue
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

# Description
This PR is intended to deal with the several issues that exist with the CLI's `list` command and `ListJobs` logic. Dead jobs would show as being alive and vice versa. While it does not solve all of the surrounding issues, and could have more informative messages , it provides an initial technical framework for improving manuscript state detection:

The major changes are as follows:
1. Implemented Manuscript State Machine in `pkg/manuscript_state.go`
2. Refactored `list` to use the Manuscript State Machine to determine Manuscript state
3. Updated `list` help documentation
4. Added `ls` alias to `list` command
5. Added directory search for `list` command - you can now search other directories besides the default one for manuscripts mimicking unix `ls` command. This was initially added for debugging purposes but proved quite useful.

Fixes #61  
R.I.P. Zombie Jobs :zombie: 

## Type of Change

- [X] Bug fix
