### PR TITLE
🔖 fix: bump Makefile version tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Variables
-VERSION ?= 1.1.0
+VERSION ?= 1.1.1
 GIT_COMMIT=$(shell git rev-parse --short HEAD)
 BUILD_DATE=$(shell date -u '+%Y-%m-%d:%H:%M:%S')
 GO_VERSION=$(shell go version | cut -d' ' -f3)


### PR DESCRIPTION

# Description

Update the version tag in the Makefile to be commensurate with the version number in both CLI and GUI files.
In reference to Commit [6208c0](https://github.com/chainbase-labs/manuscript-core/commit/6208c0052a1e55f94a111d9609050ac3b2930442)

## Type of Change

- [X] Documentation update
