### PR TITLE
✨ feat: add `config` command to CLI

### DIFF
--- a/cli/commands/commander.go
+++ b/cli/commands/commander.go
@@ -71,9 +71,27 @@ Usage:
 
 var configShowCmd = &cobra.Command{
 	Use:   "show",
-	Short: "Show current manuscript configuration",
+	Short: "Show manuscript configuration",
+	Long: `📋 Show Manuscript Configuration
+
+Options:
+--summary  Show condensed overview of configuration
+
+Display includes:
+• Config file location
+• Base directory
+• Manuscript counts
+• Port assignments
+• Disk vs config differences`,
+	Example: `>> manuscript-cli config show
+>> manuscript-cli config show --summary`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ConfigShow()
+		summary, _ := cmd.Flags().GetBool("summary")
+		if summary {
+			ShowConfigSummary()
+		} else {
+			ConfigShow()
+		}
 	},
 }
 
@@ -286,9 +304,10 @@ func init() {
 	// Utility commands
 	rootCmd.AddCommand(versionCmd)
 
-	// Add flags to config clean command
+	// Add flags to config subcommands
 	configCleanCmd.Flags().Bool("all", false, "Remove all manuscripts")
 	configCleanCmd.Flags().Bool("force", false, "Skip confirmation for removal")
+	configShowCmd.Flags().BoolP("summary", "s", false, "Show condensed overview of configuration")
 
 	// Configure deployment flags
 	deployManuscript.Flags().StringVar(&env, "env", "", "Specify the environment to deploy (local or chainbase)")

--- a/cli/commands/commander.go
+++ b/cli/commands/commander.go
@@ -94,7 +94,7 @@ Display includes:
 	Run: func(cmd *cobra.Command, args []string) {
 		summary, _ := cmd.Flags().GetBool("summary")
 		if summary {
-			ShowConfigSummary()
+			ConfigShowSummary()
 		} else {
 			ConfigShow()
 		}

--- a/cli/commands/commander.go
+++ b/cli/commands/commander.go
@@ -47,6 +47,44 @@ You'll be prompted to select:
 	},
 }
 
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage manuscript configuration",
+	Long: `🔧 Manage Manuscript Configuration
+
+Actions:
+📁 View config file location
+📋 Show current configuration
+🧹 Clean configuration file
+
+Usage:
+- Run without arguments to see config location
+- Use 'show' to view full configuration
+- Use 'clean' to remove all configurations`,
+	Example: `>> manuscript-cli config
+>> manuscript-cli config show
+>> manuscript-cli config clean`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigLocation()
+	},
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show current manuscript configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigShow()
+	},
+}
+
+var configCleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Clean manuscript configuration file",
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigClean()
+	},
+}
+
 var jobListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
@@ -211,6 +249,11 @@ func init() {
 	// Manuscript creation & deployment commands
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(deployManuscript)
+
+	// Add config commands
+	configCmd.AddCommand(configShowCmd)
+	configCmd.AddCommand(configCleanCmd)
+	rootCmd.AddCommand(configCmd)
 
 	// Job management commands
 	rootCmd.AddCommand(jobListCmd)

--- a/cli/commands/commander.go
+++ b/cli/commands/commander.go
@@ -13,6 +13,7 @@ var (
 	version = "1.1.1"
 )
 
+// Execute runs the CLI commands
 func Execute(args []string) error {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -21,6 +22,8 @@ func Execute(args []string) error {
 	return nil
 }
 
+// *** MAIN COMMANDS *** //
+// `init` command to initialize a new manuscript project
 var initCmd = &cobra.Command{
 	Use:     "init",
 	Aliases: []string{"ini", "in", "i"},
@@ -47,6 +50,7 @@ You'll be prompted to select:
 	},
 }
 
+// `config` command to manage manuscript configuration
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Manage manuscript configuration",
@@ -69,6 +73,8 @@ Usage:
 	},
 }
 
+// SUB-COMMANDS for `config` command //
+// `config show` command to display manuscript configuration
 var configShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Show manuscript configuration",
@@ -95,6 +101,7 @@ Display includes:
 	},
 }
 
+// `config clean` command to remove manuscript configurations from config file
 var configCleanCmd = &cobra.Command{
 	Use:   "clean [manuscript-names...]",
 	Short: "Clean manuscript configuration file",
@@ -123,6 +130,8 @@ Examples:
 	},
 }
 
+// *** JOB COMMANDS *** //
+// `list` command to show all manuscript jobs
 var jobListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
@@ -156,6 +165,7 @@ Usage:
 	},
 }
 
+// `stop` command to stop a manuscript job
 var jobStopCmd = &cobra.Command{
 	Use:   "stop <job_name>",
 	Short: "Stop a manuscript job",
@@ -175,6 +185,7 @@ Note: Restart jobs using 'deploy' command`,
 	},
 }
 
+// `logs` command to view logs of a manuscript job
 var jobLogsCmd = &cobra.Command{
 	Use:   "logs <job_name>",
 	Short: "View logs of a manuscript job",
@@ -192,6 +203,8 @@ Shows:
 		JobLogs(args[0])
 	},
 }
+
+// `chat` command to chat with the dataset AI for Text-2-SQL queries
 var chatCmd = &cobra.Command{
 	Use:     "chat <job_name>",
 	Aliases: []string{"c"},
@@ -222,6 +235,7 @@ Required Env Vars:
 	},
 }
 
+// `deploy` command to deploy a manuscript.yaml file
 var deployManuscript = &cobra.Command{
 	Use:     "deploy <manuscript-file>",
 	Aliases: []string{"d"},
@@ -259,6 +273,8 @@ Requirements:
 	},
 }
 
+// *** UTILITY COMMANDS *** //
+// `version` command to show the version of manuscript-cli
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show the version of manuscript-cli",
@@ -277,13 +293,24 @@ Shows:
 }
 
 func init() {
-	// Configure help from help_template.go
+	// Set help from help_template.go for root command
 	configureHelp(rootCmd)
 
 	// Ensure commands show up as added instead of alphabetically
 	cobra.EnableCommandSorting = false
 
-	// Add CLI commands in logical groups
+	// Add commands to root
+	addCLICommands()
+
+	// Add flags to each command and subcommand
+	configureFlags()
+
+	// Disable the default completion command
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+}
+
+// Add CLI commands in logical groups
+func addCLICommands() {
 	// Manuscript creation & deployment commands
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(deployManuscript)
@@ -304,6 +331,10 @@ func init() {
 	// Utility commands
 	rootCmd.AddCommand(versionCmd)
 
+}
+
+// Configure flags for each command
+func configureFlags() {
 	// Add flags to config subcommands
 	configCleanCmd.Flags().Bool("all", false, "Remove all manuscripts")
 	configCleanCmd.Flags().Bool("force", false, "Skip confirmation for removal")
@@ -315,11 +346,9 @@ func init() {
 
 	// Configure version command flags
 	versionCmd.Flags().BoolP("verbose", "v", false, "Display detailed version information")
-
-	// Disable the default completion command
-	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 }
 
+// Default Command for CLI
 var rootCmd = &cobra.Command{
 	Use: "manuscript-cli [command]",
 }

--- a/cli/commands/commander.go
+++ b/cli/commands/commander.go
@@ -78,10 +78,30 @@ var configShowCmd = &cobra.Command{
 }
 
 var configCleanCmd = &cobra.Command{
-	Use:   "clean",
+	Use:   "clean [manuscript-names...]",
 	Short: "Clean manuscript configuration file",
+	Long: `🧹 Clean Manuscript Configuration
+
+Options:
+--all    Remove all manuscripts
+--force  Skip confirmation for removal
+
+Examples:
+• Clean specific manuscripts with confirmation:
+  manuscript-cli config clean manuscript1 manuscript2
+
+• Clean specific manuscripts without confirmation:
+  manuscript-cli config clean manuscript1 manuscript2 --force
+
+• Clean all manuscripts with confirmation:
+  manuscript-cli config clean --all
+
+• Clean all manuscripts without confirmation:
+  manuscript-cli config clean --all --force`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ConfigClean()
+		all, _ := cmd.Flags().GetBool("all")
+		force, _ := cmd.Flags().GetBool("force")
+		ConfigClean(all, force, args)
 	},
 }
 
@@ -265,6 +285,10 @@ func init() {
 
 	// Utility commands
 	rootCmd.AddCommand(versionCmd)
+
+	// Add flags to config clean command
+	configCleanCmd.Flags().Bool("all", false, "Remove all manuscripts")
+	configCleanCmd.Flags().Bool("force", false, "Skip confirmation for removal")
 
 	// Configure deployment flags
 	deployManuscript.Flags().StringVar(&env, "env", "", "Specify the environment to deploy (local or chainbase)")

--- a/cli/commands/commander.go
+++ b/cli/commands/commander.go
@@ -74,7 +74,7 @@ Usage:
 	Run: func(cmd *cobra.Command, args []string) {
 		config, err := pkg.LoadConfig(manuscriptConfig)
 		if err != nil {
-			fmt.Println("Error: Failed to load manuscript config: %v", err)
+			fmt.Printf("Error: Failed to load manuscript config: %v", err)
 		}
 		ListJobs(config)
 	},

--- a/cli/commands/config_manuscript.go
+++ b/cli/commands/config_manuscript.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// ConfigSummary is a struct to hold summarized manuscript configuration details
 type ConfigSummary struct {
 	ConfigLocation    string
 	BaseDir           string
@@ -18,12 +19,15 @@ type ConfigSummary struct {
 	Discrepancies     []string
 }
 
+// ConfigLocation prints the location of the manuscript config file
 func ConfigLocation() {
 	configPath := os.ExpandEnv(manuscriptConfig)
 	fmt.Printf("📁 Manuscript config location: %s\n", configPath)
 }
 
+// ConfigShow prints the whole manuscript configuration as JSON
 func ConfigShow() {
+	// Load manuscript config
 	config, err := pkg.LoadConfig(manuscriptConfig)
 	if err != nil {
 		log.Fatalf("Error: Failed to load manuscript config: %v", err)
@@ -35,21 +39,27 @@ func ConfigShow() {
 		log.Fatalf("Error: Failed to marshal config: %v", err)
 	}
 
+	// Print JSON data to console
 	fmt.Printf("📋 Manuscript Configuration:\n\n%s\n", string(jsonData))
 }
 
-func ShowConfigSummary() {
+// ConfigShowSummary prints a summarized view of the manuscript configuration
+func ConfigShowSummary() {
+	// Load manuscript config
 	configPath := os.ExpandEnv(manuscriptConfig)
 	config, err := pkg.LoadConfig(manuscriptConfig)
 	if err != nil {
 		log.Fatalf("Error: Failed to load manuscript config: %v", err)
 	}
 
+	// Build summary and display
 	summary := buildConfigSummary(configPath, config)
 	displaySummary(summary)
 }
 
+// buildConfigSummary creates a ConfigSummary struct from the manuscript config
 func buildConfigSummary(configPath string, config *pkg.Config) ConfigSummary {
+	// Create summary struct
 	summary := ConfigSummary{
 		ConfigLocation:    configPath,
 		BaseDir:           config.BaseDir,
@@ -62,14 +72,19 @@ func buildConfigSummary(configPath string, config *pkg.Config) ConfigSummary {
 		if err != nil {
 			fmt.Printf("⚠️  Warning: Could not read manuscripts from disk: %v\n", err)
 		}
+		// Tracks manuscripts which are in the base directory but not in the config
 		summary.DiskManuscripts = manuscripts
+		// Find discrepancies between disk and config
 		summary.Discrepancies = findDiscrepancies(manuscripts, config.Manuscripts)
 	}
 
+	// Return summary
 	return summary
 }
 
+// findManuscriptsOnDisk reads the base directory and returns a list of manuscripts
 func findManuscriptsOnDisk(baseDir string) ([]string, error) {
+	// Find all manuscripts in the manuscripts directory
 	var manuscripts []string
 	manuscriptsDir := filepath.Join(baseDir, "manuscripts")
 
@@ -78,6 +93,7 @@ func findManuscriptsOnDisk(baseDir string) ([]string, error) {
 		return nil, err
 	}
 
+	// Check each entry in the directory
 	for _, entry := range entries {
 		if entry.IsDir() {
 			// Check if manuscript.yaml exists in the directory
@@ -87,9 +103,11 @@ func findManuscriptsOnDisk(baseDir string) ([]string, error) {
 			}
 		}
 	}
+	// Return list of manuscripts
 	return manuscripts, nil
 }
 
+// findDiscrepancies compares manuscripts on disk with those in the config
 func findDiscrepancies(diskMss []string, configMss []pkg.Manuscript) []string {
 	var discrepancies []string
 	configMap := make(map[string]bool)
@@ -117,9 +135,11 @@ func findDiscrepancies(diskMss []string, configMss []pkg.Manuscript) []string {
 		}
 	}
 
+	// Return discrepancies as a list of strings
 	return discrepancies
 }
 
+// displaySummary prints the ConfigSummary struct to the console in a human-readable format
 func displaySummary(summary ConfigSummary) {
 	fmt.Println("\n📊 Manuscript Configuration Summary")
 	fmt.Println("──────────────────────────────────")
@@ -147,12 +167,15 @@ func displaySummary(summary ConfigSummary) {
 	}
 }
 
+// ConfigClean removes manuscript configurations from the config file
 func ConfigClean(all bool, force bool, manuscripts []string) {
+	// Load manuscript config
 	config, err := pkg.LoadConfig(manuscriptConfig)
 	if err != nil {
 		log.Fatalf("Error: Failed to load manuscript config: %v", err)
 	}
 
+	// check if all flag is set
 	if all {
 		if !force {
 			fmt.Print("⚠️  Warning: This will remove all manuscript configurations. Continue? (y/N): ")
@@ -171,10 +194,12 @@ func ConfigClean(all bool, force bool, manuscripts []string) {
 			Manuscripts: []pkg.Manuscript{},
 		})
 
+		// Check for errors
 		if err != nil {
 			log.Fatalf("Error: Failed to clean config: %v", err)
 		}
 
+		// Print success message
 		fmt.Println("🧹 All manuscript configurations cleaned successfully!")
 		return
 	}
@@ -228,11 +253,13 @@ func ConfigClean(all bool, force bool, manuscripts []string) {
 			}
 		}
 
+		// Add manuscript to remaining list if it should be kept
 		if shouldKeep {
 			remainingManuscripts = append(remainingManuscripts, ms)
 		}
 	}
 
+	// Save updated config with remaining manuscripts
 	if removedCount > 0 {
 		err := pkg.SaveConfigFresh(manuscriptConfig, &pkg.Config{
 			BaseDir:     config.BaseDir,
@@ -240,12 +267,15 @@ func ConfigClean(all bool, force bool, manuscripts []string) {
 			Manuscripts: remainingManuscripts,
 		})
 
+		// Check for errors
 		if err != nil {
 			log.Fatalf("Error: Failed to update config: %v", err)
 		}
 
+		// Print success message
 		fmt.Printf("🧹 Successfully removed %d manuscript(s)\n", removedCount)
 	} else {
+		// No manuscripts removed
 		fmt.Println("ℹ️  No manuscripts were removed")
 	}
 }
@@ -260,6 +290,7 @@ func contains(slice []string, str string) bool {
 	return false
 }
 
+// Helper function removeManuscriptsFromConfig removes specific manuscripts from the config
 func removeManuscriptsFromConfig(config *pkg.Config, manuscriptsToRemove []string, force bool) (*pkg.Config, int) {
 	var remainingManuscripts []pkg.Manuscript
 	removedCount := 0
@@ -303,6 +334,7 @@ func removeManuscriptsFromConfig(config *pkg.Config, manuscriptsToRemove []strin
 			}
 		}
 
+		// Add manuscript to remaining list if it should be kept
 		if shouldKeep {
 			remainingManuscripts = append(remainingManuscripts, ms)
 		}
@@ -316,6 +348,7 @@ func removeManuscriptsFromConfig(config *pkg.Config, manuscriptsToRemove []strin
 	}, removedCount
 }
 
+// Helper function to confirm removal of a manuscript
 func confirmRemoval() bool {
 	var response string
 	fmt.Scanln(&response)

--- a/cli/commands/config_manuscript.go
+++ b/cli/commands/config_manuscript.go
@@ -1,0 +1,132 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"manuscript-core/pkg"
+	"os"
+	"strings"
+)
+
+func ConfigLocation() {
+	configPath := os.ExpandEnv(manuscriptConfig)
+	fmt.Printf("📁 Manuscript config location: %s\n", configPath)
+}
+
+func ConfigShow() {
+	config, err := pkg.LoadConfig(manuscriptConfig)
+	if err != nil {
+		log.Fatalf("Error: Failed to load manuscript config: %v", err)
+	}
+
+	// Convert config to JSON for pretty printing
+	jsonData, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		log.Fatalf("Error: Failed to marshal config: %v", err)
+	}
+
+	fmt.Printf("📋 Manuscript Configuration:\n\n%s\n", string(jsonData))
+}
+
+func ConfigClean(selective bool, manuscripts []string) {
+	config, err := pkg.LoadConfig(manuscriptConfig)
+	if err != nil {
+		log.Fatalf("Error: Failed to load manuscript config: %v", err)
+	}
+
+	// Keep track of original system settings
+	originalBaseDir := config.BaseDir
+	originalSystemInfo := config.SystemInfo
+
+	if !selective {
+		// Clean all manuscripts mode
+		fmt.Print("⚠️  Warning: This will remove all manuscript configurations. Continue? (y/N): ")
+		var response string
+		fmt.Scanln(&response)
+
+		if strings.ToLower(response) != "y" {
+			fmt.Println("Operation cancelled.")
+			return
+		}
+
+		// Create new config preserving system settings
+		err := pkg.SaveConfig(manuscriptConfig, &pkg.Config{
+			BaseDir:     originalBaseDir,    // Preserve original BaseDir
+			SystemInfo:  originalSystemInfo, // Preserve original SystemInfo
+			Manuscripts: []pkg.Manuscript{},
+		})
+
+		if err != nil {
+			log.Fatalf("Error: Failed to clean config: %v", err)
+		}
+
+		fmt.Println("🧹 All manuscript configurations cleaned successfully!")
+		return
+	}
+
+	// Selective cleaning mode
+	var remainingManuscripts []pkg.Manuscript
+	var removedCount int
+
+	for _, ms := range config.Manuscripts {
+		if len(manuscripts) > 0 {
+			// If specific manuscripts were provided
+			if contains(manuscripts, ms.Name) {
+				fmt.Printf("Remove manuscript '%s'? (y/N): ", ms.Name)
+				var response string
+				fmt.Scanln(&response)
+
+				if strings.ToLower(response) != "y" {
+					remainingManuscripts = append(remainingManuscripts, ms)
+					fmt.Printf("Keeping manuscript '%s'\n", ms.Name)
+				} else {
+					fmt.Printf("Removed manuscript '%s'\n", ms.Name)
+					removedCount++
+				}
+			} else {
+				remainingManuscripts = append(remainingManuscripts, ms)
+			}
+		} else {
+			// If no specific manuscripts were provided, ask for each
+			fmt.Printf("Remove manuscript '%s'? (y/N): ", ms.Name)
+			var response string
+			fmt.Scanln(&response)
+
+			if strings.ToLower(response) != "y" {
+				remainingManuscripts = append(remainingManuscripts, ms)
+				fmt.Printf("Keeping manuscript '%s'\n", ms.Name)
+			} else {
+				fmt.Printf("Removed manuscript '%s'\n", ms.Name)
+				removedCount++
+			}
+		}
+	}
+
+	// Save updated config
+	err = pkg.SaveConfig(manuscriptConfig, &pkg.Config{
+		BaseDir:     originalBaseDir,
+		SystemInfo:  originalSystemInfo,
+		Manuscripts: remainingManuscripts,
+	})
+
+	if err != nil {
+		log.Fatalf("Error: Failed to update config: %v", err)
+	}
+
+	if removedCount > 0 {
+		fmt.Printf("🧹 Successfully removed %d manuscript(s)\n", removedCount)
+	} else {
+		fmt.Println("ℹ️  No manuscripts were removed")
+	}
+}
+
+// Helper function to check if a string is in a slice
+func contains(slice []string, str string) bool {
+	for _, v := range slice {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Checklist:

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [X] Please open an issue before creating a PR or link to an existing issue
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

# Description
This PR offers quality of life improvements for developers who are looking to debug their manuscript without extensive navigation of the file system. Simply, it sets the standard for manuscript configuration directly from the CLI. This can be tremendously helpful for gathering information about errors.

Current improvements include the following:

- clean up/refactor `commander.go` to use helper functions
- new `config` command
   - Shows config file location when run without subcommands
   - Path resolves to `$HOME/.manuscript_config.ini`
-  new `config show` subcommand!
   - Displays full configuration in JSON format
   - Added `--summary/-s` flag for condensed view showing:
     - Config location and base directory
     - Manuscript counts (disk vs config)
     - Horizontal listing of manuscripts with port assignments
     - Discrepancy detection between disk and config entries
- new `config clean` subcommand!
   - Implements selective manuscript removal from config
   - Added flags:
     - `--all`: Remove all manuscripts
     - `--force`: Skip confirmation prompts
   - Preserves system settings (BaseDir, SystemInfo)
   - Uses new `SaveConfigFresh` function for atomic writes
- Added `SaveConfigFresh` to `manuscript_config.go` to handle clean config writes without merging

## Future Considerations

In the future the following should be considered:

1. Allow direct manipulation of other configuration settings from the CLI , i.e. (`config --set-base-dir`)
2. Allow hard delete / purging of manuscript files on disk with an additional `--destructive` flag (`config clean -d`)
3. Rework `list` function to look at manuscripts in the specified base_dir in config file and secondarily manuscripts in a chosen directory (taken as an argument) as it worked in #96 . Looking at manuscripts in config file using `list` is now redundant.

## Related Issue

Partially Addresses **2** out of **4** Issues Raised in #101

- [x] a `config` command that allows a user to DISPLAY and CHANGE aspects of their config file. Also, tells a user its path on disk.
- [x] a `clean` command or flag that allows a user to WHOLLY wipe out their config file, or WIPE all manuscripts
- [ ] a `start` command where a user can deploy any manuscript from a config without listing the entire path or parameters for the manuscript in question (this would speed up deploys & make better use of the manuscript_config.ini)  ref: #101
- [ ] a global `--config` flag that allows most commands to run from the specified config file instead of one in the default location


## Base Command Usage

```bash
$ manuscript-cli config
📁 Manuscript config location: /home/user/.manuscript_config.ini
```

## Sub Command 1 Usage 
```bash
$ manuscript-cli config show
📋 Manuscript Configuration:
{
  "BaseDir": "/home/user/manuscripts",
  "SystemInfo": "linux",
  "Manuscripts": [
    {
      "Name": "demo",
      "Port": 8081,
      ...
    }
  ]
}

$ manuscript-cli config show --summary

📊 Manuscript Configuration Summary
──────────────────────────────────
📁 Config Location: /home/kagemnikarimu/.manuscript_config.ini
📂 Manuscripts Directory: /home/kagemnikarimu/manuscripts

📈 Statistics:
   • Manuscripts on disk: 0
   • Manuscripts in config: 0

🔍 Configured Manuscripts:
```

## Sub Command 2 Usage

```bash
# Force remove specific manuscripts (no confirmation)
$ manuscript-cli config clean manuscript1 manuscript2 --force
Removed manuscript 'manuscript1'
Removed manuscript 'manuscript2'
🧹 Successfully removed 2 manuscript(s)

# Force remove all manuscripts (no confirmation)
$ manuscript-cli config clean --all --force
🧹 All manuscript configurations cleaned successfully!

# Clean all interactively (without force)
$ manuscript-cli config clean --all
⚠️  Warning: This will remove all manuscript configurations. Continue? (y/N): y
🧹 All manuscript configurations cleaned successfully!

# Clean specific manuscripts interactively (without force)
$ manuscript-cli config clean manuscript1 manuscript2
Remove manuscript 'manuscript1'? (y/N): y
Removed manuscript 'manuscript1'
Remove manuscript 'manuscript2'? (y/N): n
Keeping manuscript 'manuscript2'
🧹 Successfully removed 1 manuscript(s)
```

## Screenshots
`config show --summary` before running `config clean --all` :
![image](https://github.com/user-attachments/assets/60415d9d-1ff3-4685-866c-d38b0dca7b08)
`config show -s` after running `config clean --all`:
![image](https://github.com/user-attachments/assets/6deb8d52-ea91-4078-a1d1-a2268c2c48f3)



## Type of Change

- [X] New feature
- [X] Enhancement, including but not limited to code refactoring, performance optimization, Test and CI
